### PR TITLE
Ensure that str and unicode representations of StringUUID match.

### DIFF
--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -16,6 +16,9 @@ class StringUUID(uuid.UUID):
     def __unicode__(self):
         return self.hex
 
+    def __str__(self):
+        return self.hex
+
     def __len__(self):
         return len(self.__unicode__())
 


### PR DESCRIPTION
This is fixing an issue where the str(..) representation was being used when pushing data to the database, causing warnings/failures about data truncation into the 32 bit field when a 36 bit value was returned.

Config hitting the issue was:
Python 2.6.5
Django 1.4
