### PR TITLE
Python 3 support

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -22,7 +22,7 @@ if not settings.configured:
         DEBUG=False,
     )
 
-from django_nose import NoseTestSuiteRunner
+from django.test.simple import DjangoTestSuiteRunner
 
 
 def runtests(*test_args, **kwargs):
@@ -35,7 +35,7 @@ def runtests(*test_args, **kwargs):
 
     kwargs.setdefault('interactive', False)
 
-    test_runner = NoseTestSuiteRunner(**kwargs)
+    test_runner = DjangoTestSuiteRunner(**kwargs)
 
     failures = test_runner.run_tests(test_args)
     sys.exit(failures)
@@ -43,7 +43,7 @@ def runtests(*test_args, **kwargs):
 if __name__ == '__main__':
     parser = OptionParser()
     parser.add_option('--verbosity', dest='verbosity', action='store', default=1, type=int)
-    parser.add_options(NoseTestSuiteRunner.options)
+    parser.add_options(DjangoTestSuiteRunner.options)
     (options, args) = parser.parse_args()
 
     runtests(*args, **options.__dict__)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     ],
     tests_require=[
         'psycopg2',
-        'django-nose',
     ],
     packages=find_packages(),
     test_suite='runtests.runtests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,24 @@
 [testenv]
+envlist = py33-1.5.X,py27-1.5.X,py27-1.4.X,py26-1.5.X,py26-1.4.X
 downloadcache = {toxworkdir}/_download/
-deps =
-    Django==1.3.1
-    psycopg2==2.4.1
-    django-nose
-commands =
-    {envbindir}/python setup.py test
+commands = {envbindir}/python setup.py test
+
+[testenv:py33-1.5.X]
+basepython = python3.3
+deps = Django==1.5.1
+
+[testenv:py27-1.5.X]
+basepython = python2.7
+deps = Django==1.5.1
+
+[testenv:py27-1.4.X]
+basepython = python2.7
+deps = Django==1.4.5
+
+[testenv:py26-1.5.X]
+basepython = python2.6
+deps = Django==1.5.1
+
+[testenv:py26-1.4.X]
+basepython = python2.6
+deps = Django==1.4.5

--- a/uuidfield/__init__.py
+++ b/uuidfield/__init__.py
@@ -1,7 +1,7 @@
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution('django-uuidfield').version
-except Exception, e:
+except Exception as e:
     VERSION = 'unknown'
-    
-from fields import UUIDField
+
+from uuidfield.fields import UUIDField

--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -2,7 +2,13 @@ import uuid
 
 from django import forms
 from django.db.models import Field, SubfieldBase
-from django.utils.encoding import smart_unicode
+
+from django.utils.six import PY3
+
+if PY3:
+    from django.utils.encoding import smart_text
+else:
+    from django.utils.encoding import smart_unicode as smart_text
 
 try:
     # psycopg2 needs us to register the uuid type
@@ -98,6 +104,10 @@ class UUIDField(Field):
         """
         if isinstance(value, uuid.UUID):
             return str(value)
+
+        if not value:
+            return None
+
         return value
 
     def value_to_string(self, obj):
@@ -119,7 +129,7 @@ class UUIDField(Field):
             return None
         # attempt to parse a UUID including cases in which value is a UUID
         # instance already to be able to get our StringUUID in.
-        return StringUUID(smart_unicode(value))
+        return StringUUID(smart_text(value))
 
     def formfield(self, **kwargs):
         defaults = {

--- a/uuidfield/tests/__init__.py
+++ b/uuidfield/tests/__init__.py
@@ -1,2 +1,2 @@
-from tests import *
-from models import *
+from .tests import *
+from .models import *

--- a/uuidfield/tests/tests.py
+++ b/uuidfield/tests/tests.py
@@ -12,7 +12,7 @@ class UUIDFieldTestCase(TestCase):
     def test_auto_uuid4(self):
         obj = AutoUUIDField.objects.create()
         self.assertTrue(obj.uuid)
-        self.assertEquals(len(obj.uuid), 32)
+        self.assertEquals(len(obj.uuid.hex), 32)
         self.assertTrue(isinstance(obj.uuid, uuid.UUID))
         self.assertEquals(obj.uuid.version, 4)
 
@@ -22,14 +22,14 @@ class UUIDFieldTestCase(TestCase):
     def test_manual(self):
         obj = ManualUUIDField.objects.create(uuid=uuid.uuid4())
         self.assertTrue(obj)
-        self.assertEquals(len(obj.uuid), 32)
+        self.assertEquals(len(obj.uuid.hex), 32)
         self.assertTrue(isinstance(obj.uuid, uuid.UUID))
         self.assertEquals(obj.uuid.version, 4)
 
     def test_namespace(self):
         obj = NamespaceUUIDField.objects.create()
         self.assertTrue(obj)
-        self.assertEquals(len(obj.uuid), 32)
+        self.assertEquals(len(obj.uuid.hex), 32)
         self.assertTrue(isinstance(obj.uuid, uuid.UUID))
         self.assertEquals(obj.uuid.version, 5)
 


### PR DESCRIPTION
I started work on Python 3 support today, since I'm trying to port an app of mine that uses django-uuidfield. You can see the beginnings of my work at https://github.com/dominicrodger/django-uuidfield/compare/py3.

I'm mostly there, there are two outstanding issues:

1. There's one failing test that I'd appreciate some help with if anyone's got any Python 3/Django/Postgres experience - `test_raises_exception` throws a `psycopg2.DataError` at the moment), but it did require switching the tests out from using django-nose to using the default Django test runner, since django-nose doesn't support Python 3 (see https://github.com/jbalogh/django-nose/pull/103). I'm not sure django-nose gets us a lot - it seems to run all the tests twice (I get 10 tests run, even though there are only 5 tests - if I add a simple failing test, I get 12 tests run, 2 failed), and the normal Django runner correctly runs 5 tests.
2. I'm not quite sure what the purpose of `smart_unicode` in `to_python` - the tests don't seem to hit it. I'm guessing just using `django.utils.smart_text` is the right approach if `smart_unicode` is still needed.

I've run the unit tests on Python 2.6, 2.7 and with Django 1.4.5 and 1.5.1 (as you'll see from my changes to `tox.ini`).

Does this approach look reasonable? If so, I'll tidy it up, figure out the Postgres issue and send a pull request.