### PR TITLE
Always return unicode string for StringUUID.__unicode__

### DIFF
--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -20,7 +20,7 @@ class StringUUID(uuid.UUID):
         super(StringUUID, self).__init__(*args, **kwargs)
 
     def __unicode__(self):
-        return unicode(str(self))
+        return u'%s' % str(self)
 
     def __str__(self):
         if self.hyphenate:


### PR DESCRIPTION
Refs django/django#20856 -- https://code.djangoproject.com/ticket/20856#comment:11
