### PR TITLE
fix prefetch related with UUID fields

### DIFF
--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -37,11 +37,6 @@ class StringUUID(uuid.UUID):
     def __hash__(self):
         return self.__unicode__().__hash__()
    
-    def __cmp__(self, other):
-        # since foreign keys are stored as the hex representation, we
-        # want to ensure that comparisions are strings without the '-'s
-        return self.__unicode__().__cmp__(unicode(other).replace('-', ''))
-   
     def __eq__(self, other):
         return self.__unicode__().__eq__(unicode(other).replace('-', ''))
 

--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -34,6 +34,17 @@ class StringUUID(uuid.UUID):
     def __len__(self):
         return len(self.__unicode__())
 
+    def __hash__(self):
+        return self.__unicode__().__hash__()
+   
+    def __cmp__(self, other):
+        # since foreign keys are stored as the hex representation, we
+        # want to ensure that comparisions are strings without the '-'s
+        return self.__unicode__().__cmp__(unicode(other).replace('-', ''))
+   
+    def __eq__(self, other):
+        return self.__unicode__().__eq__(unicode(other).replace('-', ''))
+
 
 class UUIDField(Field):
     """


### PR DESCRIPTION
Because the foreign key is stored as a string (char field) and
the uuid field is returned as a UUID (StringUUID) object, prefetch
related does not work.

This patch makes StringUUID dict keys equivelent to string dict
keys.
