### PR TITLE
Remove "(calculated using the UUID1 method)" doc

### DIFF
--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -37,10 +37,10 @@ class StringUUID(uuid.UUID):
 
 class UUIDField(Field):
     """
-    A field which stores a UUID value in hex format. This may also have
-    the Boolean attribute 'auto' which will set the value on initial save to a
-    new UUID value (calculated using the UUID1 method). Note that while all
-    UUIDs are expected to be unique we enforce this with a DB constraint.
+    A field which stores a UUID value in hex format. This may also have the
+    Boolean attribute 'auto' which will set the value on initial save to a new
+    UUID value. Note that while all UUIDs are expected to be unique we enforce
+    this with a DB constraint.
     """
     # TODO: support binary storage types
     __metaclass__ = SubfieldBase


### PR DESCRIPTION
When auto=True, the UUID is generated using the specified version, not necessarily UUID1.
