### PR TITLE
Update problem with hyphenate.

### DIFF
--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -48,7 +48,8 @@ class UUIDField(Field):
     def __init__(self, version=4, node=None, clock_seq=None,
                  namespace=None, name=None, auto=False, hyphenate=False,
                  *args, **kwargs):
-        assert version in (1, 3, 4, 5), "UUID version %s is not supported." % version
+        assert version in (1, 3, 4, 5), "UUID version {ver}is not supported."\
+            .format(ver=version)
         self.auto = auto
         self.version = version
         self.hyphenate = hyphenate


### PR DESCRIPTION
When the hyphenate option is used, a little bug to update the object, because we display the field with dash and the max length for the field is set to 32. When the hyphenate is used we store the uuid in string format, not in hexedecimal format, so I think we can change the max length to 36 when hyphenate option is used.
