### PR TITLE
Raise ValueError in get_db_prep_value() when value is of invalid length

### DIFF
--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -118,7 +118,9 @@ class UUIDField(Field):
             value = str(value)
         if isinstance(value, str):
             if '-' in value:
-                return value.replace('-', '')
+                value = value.replace('-', '')
+        if value and len(value) != 32:
+            raise ValueError('badly formed hexadecimal UUID string')
         return value
 
     def value_to_string(self, obj):

--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -119,8 +119,7 @@ class UUIDField(Field):
         if isinstance(value, str):
             if '-' in value:
                 value = value.replace('-', '')
-        if value and len(value) != 32:
-            raise ValueError('badly formed hexadecimal UUID string')
+            uuid.UUID(value) # raises ValueError with invalid UUID format
         return value
 
     def value_to_string(self, obj):

--- a/uuidfield/tests/tests.py
+++ b/uuidfield/tests/tests.py
@@ -34,15 +34,19 @@ class UUIDFieldTestCase(TestCase):
         self.assertEquals(obj.uuid.version, 5)
 
     def test_long_uuid(self):
-        obj = AutoUUIDField.objects.create()
-        invalid_uuid = str(obj.uuid) + "1"
+        invalid_uuid = "1" * 33
         self.assertRaises(ValueError, AutoUUIDField.objects.get, uuid=invalid_uuid)
         q = AutoUUIDField.objects.filter(uuid=invalid_uuid)
         self.assertRaises(ValueError, list, q)
 
     def test_short_uuid(self):
-        obj = AutoUUIDField.objects.create()
-        invalid_uuid = str(obj.uuid)[:-1]
+        invalid_uuid = "1" * 31
+        self.assertRaises(ValueError, AutoUUIDField.objects.get, uuid=invalid_uuid)
+        q = AutoUUIDField.objects.filter(uuid=invalid_uuid)
+        self.assertRaises(ValueError, list, q)
+
+    def test_invalid_hex(self):
+        invalid_uuid = 'z' * 32
         self.assertRaises(ValueError, AutoUUIDField.objects.get, uuid=invalid_uuid)
         q = AutoUUIDField.objects.filter(uuid=invalid_uuid)
         self.assertRaises(ValueError, list, q)

--- a/uuidfield/tests/tests.py
+++ b/uuidfield/tests/tests.py
@@ -33,6 +33,20 @@ class UUIDFieldTestCase(TestCase):
         self.assertTrue(isinstance(obj.uuid, uuid.UUID))
         self.assertEquals(obj.uuid.version, 5)
 
+    def test_long_uuid(self):
+        obj = AutoUUIDField.objects.create()
+        invalid_uuid = str(obj.uuid) + "1"
+        self.assertRaises(ValueError, AutoUUIDField.objects.get, uuid=invalid_uuid)
+        q = AutoUUIDField.objects.filter(uuid=invalid_uuid)
+        self.assertRaises(ValueError, list, q)
+
+    def test_short_uuid(self):
+        obj = AutoUUIDField.objects.create()
+        invalid_uuid = str(obj.uuid)[:-1]
+        self.assertRaises(ValueError, AutoUUIDField.objects.get, uuid=invalid_uuid)
+        q = AutoUUIDField.objects.filter(uuid=invalid_uuid)
+        self.assertRaises(ValueError, list, q)
+
     def test_broken_namespace(self):
         self.assertRaises(ValueError, BrokenNamespaceUUIDField.objects.create)
 


### PR DESCRIPTION
Fixes [#46](https://github.com/dcramer/django-uuidfield/issues/46).