### PR TITLE
Added a warning about migration limitation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,8 @@ First you'll need to attach a UUIDField to your class. This acts as a char(32) t
 Check out the source for more configuration values.
 
 Enjoy!
+
+Known Limitations
+=================
+
+* Migrations do not currently work when adding a UUIDField to a model. You will likely get an error like "django.db.utils.IntegrityError: UNIQUE constraint failed".


### PR DESCRIPTION
Currently Django 1.7 migrations will complain about the UNIQUE constraint failing, because the default value it puts in existing model entries is not unique.
