### PR TITLE
added empty tuple for middleware classes, Django 1.7 spits out warnings ...

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -20,6 +20,7 @@ if not settings.configured:
         ],
         ROOT_URLCONF='',
         DEBUG=False,
+        MIDDLEWARE_CLASSES=tuple(),
     )
 
 from django_nose import NoseTestSuiteRunner

--- a/runtests_sqlite.py
+++ b/runtests_sqlite.py
@@ -20,6 +20,7 @@ if not settings.configured:
         ],
         ROOT_URLCONF='',
         DEBUG=False,
+        MIDDLEWARE_CLASSES=tuple(),
     )
 
 from django_nose import NoseTestSuiteRunner


### PR DESCRIPTION
...if not defined
![screen shot 2015-03-24 at 1 20 46 pm](https://cloud.githubusercontent.com/assets/1524947/6801511/9b519830-d228-11e4-9269-961e21eb025a.png)
