### PR TITLE
py3 respects subfieldtype metaclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.egg-info/
 /dist
 .tox
+*.swp

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Installation
 
 Install it with pip (or easy_install)::
 
-	pip install django-uuidfield
+	pip install ambition-django-uuidfield
 
 Usage
 =====

--- a/publish.py
+++ b/publish.py
@@ -1,0 +1,5 @@
+import subprocess
+
+subprocess.call(['pip', 'install', 'wheel'])
+subprocess.call(['python', 'setup.py', 'clean', '--all'])
+subprocess.call(['python', 'setup.py', 'register', 'sdist', 'bdist_wheel', 'upload', '-r', 'ambition'])

--- a/publish.py
+++ b/publish.py
@@ -2,4 +2,4 @@ import subprocess
 
 subprocess.call(['pip', 'install', 'wheel'])
 subprocess.call(['python', 'setup.py', 'clean', '--all'])
-subprocess.call(['python', 'setup.py', 'register', 'sdist', 'bdist_wheel', 'upload', '-r', 'ambition'])
+subprocess.call(['python', 'setup.py', 'register', 'sdist', 'bdist_wheel', 'upload'])

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'django',
+        'six',
     ],
     tests_require=[
         'psycopg2',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-uuidfield',
-    version='0.5.0',
+    version='0.5.0.ambition',
     author='David Cramer',
     author_email='dcramer@gmail.com',
     description='UUIDField in Django',

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='django-uuidfield',
-    version='0.5.0.ambition',
+    name='ambition-django-uuidfield',
+    version='0.5.0',
     author='David Cramer',
     author_email='dcramer@gmail.com',
-    description='UUIDField in Django',
-    url='https://github.com/dcramer/django-uuidfield',
+    description='Ambition fork of dcramer/django-uuidfield, UUIDField in Django',
+    url='https://github.com/ambitioninc/django-uuidfield',
     zip_safe=False,
     install_requires=[
         'django',

--- a/uuidfield/__init__.py
+++ b/uuidfield/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 try:
     VERSION = __import__('pkg_resources') \
-        .get_distribution('django-uuidfield').version
+        .get_distribution('ambition-django-uuidfield').version
 except Exception as e:
     VERSION = 'unknown'
     

--- a/uuidfield/fields.py
+++ b/uuidfield/fields.py
@@ -1,5 +1,6 @@
 import uuid
 
+from six import with_metaclass
 from django import forms
 from django.db.models import Field, SubfieldBase
 try:
@@ -32,15 +33,13 @@ class StringUUID(uuid.UUID):
         return len(self.__str__())
 
 
-class UUIDField(Field):
+class UUIDField(with_metaclass(SubfieldBase, Field)):
     """
     A field which stores a UUID value in hex format. This may also have the
     Boolean attribute 'auto' which will set the value on initial save to a new
     UUID value. Note that while all UUIDs are expected to be unique we enforce
     this with a DB constraint.
     """
-    # TODO: support binary storage types
-    __metaclass__ = SubfieldBase
 
     def __init__(self, version=4, node=None, clock_seq=None,
                  namespace=None, name=None, auto=False, hyphenate=False,


### PR DESCRIPTION
I was wondering why deserializing a field didn't omit dashes on python3. It's because the `to_python` method was never being called because the `SubfieldType` metaclass was never being mixed in on py3.